### PR TITLE
Fixes a world memory leak

### DIFF
--- a/src/main/java/com/carpentersblocks/util/handler/EventHandler.java
+++ b/src/main/java/com/carpentersblocks/util/handler/EventHandler.java
@@ -51,9 +51,6 @@ public class EventHandler {
     /** Stores face for onBlockClicked(). */
     public static int eventFace;
 
-    /** Stores entity that hit block. */
-    public static EntityPlayer eventEntityPlayer;
-
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     /**
@@ -110,7 +107,7 @@ public class EventHandler {
         if (block instanceof BlockCoverable) {
 
             eventFace = event.face;
-            eventEntityPlayer = event.entityPlayer;
+            EntityPlayer eventEntityPlayer = event.entityPlayer;
 
             ItemStack itemStack = eventEntityPlayer.getHeldItem();
 


### PR DESCRIPTION
Removes an unused static instance of `EntityPlayer` to not leak the world object, This can be done because there are no other usages and its only needed in the event itself. (This memory leak is about 10 years old)

![image](https://github.com/GTNewHorizons/CarpentersBlocks/assets/45769595/2405e3f7-9cd0-45df-88c2-299e33edf833)
