### PR TITLE
Remove setRenderPass call in BlockCoverable

### DIFF
--- a/src/main/java/com/carpentersblocks/block/BlockCoverable.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCoverable.java
@@ -1275,7 +1275,6 @@ public class BlockCoverable extends BlockContainer {
      * Determines if this block should render in this pass.
      */
     public boolean canRenderInPass(int pass) {
-        ForgeHooksClient.setRenderPass(pass);
         return true;
     }
 


### PR DESCRIPTION
There is a call to `ForgeHooksClient.setRenderPass()` inside `canRenderInPass()` in `BlockCoverable`, which is called off of the main thread when a ISBRH is marked as a ThreadSafeISBRH with Angelica (I think so, anyways). This may have been causing a race condition during chunk updates, causing GTNewHorizons/Angelica#421. This PR removes that call. Probably needs more testing to make sure this was the culprit.