### PR TITLE
Chisel compat for textures that are block location dependent

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,3 +1,4 @@
 dependencies {
     compileOnly('com.github.GTNewHorizons:Angelica:1.0.0-alpha52:api')
+    compileOnly('com.github.GTNewHorizons:Chisel:2.15.3-GTNH:dev')
 }

--- a/src/main/java/com/carpentersblocks/api/compat/Mods.java
+++ b/src/main/java/com/carpentersblocks/api/compat/Mods.java
@@ -1,0 +1,23 @@
+package com.carpentersblocks.api.compat;
+
+import cpw.mods.fml.common.Loader;
+
+public enum Mods {
+
+    CHISEL("chisel");
+
+    public final String ID;
+
+    private Boolean modLoaded;
+
+    Mods(String ID) {
+        this.ID = ID;
+    }
+
+    public boolean isModLoaded() {
+        if (this.modLoaded == null) {
+            this.modLoaded = Loader.isModLoaded(ID);
+        }
+        return this.modLoaded;
+    }
+}

--- a/src/main/java/com/carpentersblocks/proxy/ClientProxy.java
+++ b/src/main/java/com/carpentersblocks/proxy/ClientProxy.java
@@ -1,6 +1,7 @@
 package com.carpentersblocks.proxy;
 
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.Configuration;
 
 import com.carpentersblocks.CarpentersBlocksCachedResources;
 import com.carpentersblocks.entity.item.EntityCarpentersTile;
@@ -11,12 +12,22 @@ import com.carpentersblocks.util.registry.IconRegistry;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
+
+    @Override
+    public void preInit(FMLPreInitializationEvent event, Configuration config) {
+        super.preInit(event, config);
+        if (Loader.isModLoaded("Chisel")) {
+
+        }
+    }
 
     @Override
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/carpentersblocks/proxy/ClientProxy.java
+++ b/src/main/java/com/carpentersblocks/proxy/ClientProxy.java
@@ -1,7 +1,6 @@
 package com.carpentersblocks.proxy;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.config.Configuration;
 
 import com.carpentersblocks.CarpentersBlocksCachedResources;
 import com.carpentersblocks.entity.item.EntityCarpentersTile;
@@ -12,22 +11,12 @@ import com.carpentersblocks.util.registry.IconRegistry;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
-
-    @Override
-    public void preInit(FMLPreInitializationEvent event, Configuration config) {
-        super.preInit(event, config);
-        if (Loader.isModLoaded("Chisel")) {
-
-        }
-    }
 
     @Override
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/carpentersblocks/renderer/BlockHandlerBase.java
+++ b/src/main/java/com/carpentersblocks/renderer/BlockHandlerBase.java
@@ -1,5 +1,7 @@
 package com.carpentersblocks.renderer;
 
+import static com.carpentersblocks.api.compat.Mods.CHISEL;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockGrass;
 import net.minecraft.block.BlockRailBase;
@@ -31,6 +33,7 @@ import com.carpentersblocks.util.handler.OverlayHandler;
 import com.carpentersblocks.util.handler.OverlayHandler.Overlay;
 import com.carpentersblocks.util.registry.FeatureRegistry;
 import com.carpentersblocks.util.registry.IconRegistry;
+import com.cricketcraft.chisel.api.ICarvable;
 import com.gtnewhorizons.angelica.api.ThreadSafeISBRHFactory;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
@@ -538,6 +541,18 @@ public abstract class BlockHandlerBase implements ISimpleBlockRenderingHandler, 
         return icon;
     }
 
+    protected IIcon getIcon(ItemStack itemStack, int side, IBlockAccess world, int x, int y, int z) {
+        BlockProperties.prepareItemStackForRendering(itemStack);
+        IIcon icon = renderBlocks.getIconSafe(
+                getUniqueIcon(itemStack, side, BlockProperties.toBlock(itemStack).getIcon(world, x, y, z, side)));
+
+        if (hasIconOverride[side]) {
+            icon = renderBlocks.getIconSafe(iconOverride[side]);
+        }
+
+        return icon;
+    }
+
     /**
      * Renders multiple textures to side.
      */
@@ -564,7 +579,18 @@ public abstract class BlockHandlerBase implements ISimpleBlockRenderingHandler, 
             if (BlockProperties.blockRotates(itemStack)) {
                 setTextureRotationForDirectionalBlock(side);
             }
-            setColorAndRender(itemStack, x, y, z, side, getIcon(itemStack, side));
+            if (CHISEL.isModLoaded() && Block.getBlockFromItem(itemStack.getItem()) instanceof ICarvable) {
+                setColorAndRender(
+                        itemStack,
+                        x,
+                        y,
+                        z,
+                        side,
+                        getIcon(itemStack, side, renderBlocks.blockAccess, x, y, z));
+            } else {
+                setColorAndRender(itemStack, x, y, z, side, getIcon(itemStack, side));
+            }
+
             setTextureRotation(side, tempRotation);
         }
 


### PR DESCRIPTION
Adding compat for chisels blocks with V-mapping. Connected texture maps seem like they might be extremely hard to implement unfortunately.

Before:
![2024-12-04_20 08 34](https://github.com/user-attachments/assets/e0a81bfe-3056-473c-bb9b-c1ffd7f1f311)

After:
![2024-12-04_19 53 44](https://github.com/user-attachments/assets/99507de5-ae9b-4d69-b69d-f7eb4ad1bc20)

You can see that now textures line up correctly on stairs and when carpenter's blocks are next to normal blocks.