### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/carpentersblocks/lang/en_US.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_US.lang
@@ -24,6 +24,7 @@ tile.blockCarpentersHatch.name=Carpenter's Hatch
 tile.blockCarpentersLadder.name=Carpenter's Ladder
 tile.blockCarpentersLever.name=Carpenter's Lever
 tile.blockCarpentersPressurePlate.name=Carpenter's Pressure Plate
+tile.blockCarpentersSlope.name=Carpenter's Slope
 tile.blockCarpentersSlope.wedge.name=Carpenter's Wedge Slope
 tile.blockCarpentersSlope.obliqueInterior.name=Carpenter's Oblique Interior Slope
 tile.blockCarpentersSlope.obliqueExterior.name=Carpenter's Oblique Exterior Slope


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.