### PR TITLE
Move cached resources to separate folder rather than mods folder

### DIFF
--- a/src/main/java/com/carpentersblocks/CarpentersBlocksCachedResources.java
+++ b/src/main/java/com/carpentersblocks/CarpentersBlocksCachedResources.java
@@ -39,7 +39,7 @@ public class CarpentersBlocksCachedResources extends DummyModContainer {
     private String MODID = "CarpentersBlocksCachedResources";
     private String resourceDir = FilenameUtils
             .normalizeNoEndSeparator(Minecraft.getMinecraft().mcDataDir.getAbsolutePath()) + File.separator
-            + "mods"
+            + "cache"
             + File.separator
             + CarpentersBlocks.MODID.toLowerCase();
     private static ZipFile resourcePackZipFile;


### PR DESCRIPTION
Кешированные ресурсы будут храниться не в папке модов, а в отдельной папке