### PR TITLE
Add correct translation keys for Carpenter's Tile

### DIFF
--- a/src/main/resources/assets/carpentersblocks/lang/cs_CZ.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/cs_CZ.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Tesařův květináč
 
 # ENTITIES
 entity.CarpentersTile.name=Tesařova dlaždice
+entity.CarpentersBlocks.CarpentersTile.name=Tesařova dlaždice
 
 # MESSAGES
 message.polarity_pos.name=POLARITA: Normální ruditový výstup.

--- a/src/main/resources/assets/carpentersblocks/lang/cs_CZ.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/cs_CZ.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Tesařův květináč
 gui.tile.blockCarpentersSafe.title=Tesařův sejf
 
 # ENTITIES
-entity.CarpentersTile.name=Tesařova dlaždice
 entity.CarpentersBlocks.CarpentersTile.name=Tesařova dlaždice
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/de_DE.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/de_DE.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Blumentopf des Zimmermanns
 
 # ENTITIES
 entity.CarpentersTile.name=Fliese des Zimmermanns
+entity.CarpentersBlocks.CarpentersTile.name=Fliese des Zimmermanns
 
 # MESSAGES
 message.polarity_pos.name=POLARITÄT: Normaler Redstone-Output.

--- a/src/main/resources/assets/carpentersblocks/lang/de_DE.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/de_DE.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Blumentopf des Zimmermanns
 gui.tile.blockCarpentersSafe.title=Tresor des Zimmermanns
 
 # ENTITIES
-entity.CarpentersTile.name=Fliese des Zimmermanns
 entity.CarpentersBlocks.CarpentersTile.name=Fliese des Zimmermanns
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/en_AU.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_AU.lang
@@ -37,7 +37,6 @@ tile.blockCarpentersFlowerPot.name=Carpenter's Vase
 gui.tile.blockCarpentersSafe.title=Carpenter's Safe
 
 # ENTITIES
-entity.CarpentersTile.name=Carpenter's Tile
 entity.CarpentersBlocks.CarpentersTile.name=Carpenter's Tile
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/en_AU.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_AU.lang
@@ -35,6 +35,7 @@ tile.blockCarpentersFlowerPot.name=Carpenter's Vase
 
 # ENTITIES
 entity.CarpentersTile.name=Carpenter's Tile
+entity.CarpentersBlocks.CarpentersTile.name=Carpenter's Tile
 
 # MESSAGES
 message.polarity_pos.name=POLARITY: Normal redstone output.

--- a/src/main/resources/assets/carpentersblocks/lang/en_PT.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_PT.lang
@@ -37,7 +37,6 @@ tile.blockCarpentersFlowerPot.name=Stumpcutter's Dirt Vase
 gui.tile.blockCarpentersSafe.title=Stumpcutter's Booty Box
 
 # ENTITIES
-entity.CarpentersTile.name=Stumpcutter's Shiny Plate
 entity.CarpentersBlocks.CarpentersTile.name=Stumpcutter's Shiny Plate
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/en_PT.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_PT.lang
@@ -35,6 +35,7 @@ tile.blockCarpentersFlowerPot.name=Stumpcutter's Dirt Vase
 
 # ENTITIES
 entity.CarpentersTile.name=Stumpcutter's Shiny Plate
+entity.CarpentersBlocks.CarpentersTile.name=Stumpcutter's Shiny Plate
 
 # MESSAGES
 message.polarity_pos.name=POLARITY: Reg'lar Magic Powder Fizzin'

--- a/src/main/resources/assets/carpentersblocks/lang/en_US.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_US.lang
@@ -37,6 +37,7 @@ tile.blockCarpentersFlowerPot.name=Carpenter's Flower Pot
 
 # ENTITIES
 entity.CarpentersTile.name=Carpenter's Tile
+entity.CarpentersBlocks.CarpentersTile.name=Carpenter's Tile
 
 # MESSAGES
 message.polarity_pos.name=POLARITY: Normal redstone output.

--- a/src/main/resources/assets/carpentersblocks/lang/en_US.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/en_US.lang
@@ -39,7 +39,6 @@ tile.blockCarpentersFlowerPot.name=Carpenter's Flower Pot
 gui.tile.blockCarpentersSafe.title=Carpenter's Safe
 
 # ENTITIES
-entity.CarpentersTile.name=Carpenter's Tile
 entity.CarpentersBlocks.CarpentersTile.name=Carpenter's Tile
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/es_ES.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/es_ES.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Maceta de flores de carpintero
 gui.tile.blockCarpentersSafe.title=Seguro de carpintero
 
 # ENTITIES
-entity.CarpentersTile.name=Tile de carpintero
 entity.CarpentersBlocks.CarpentersTile.name=Tile de carpintero
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/es_ES.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/es_ES.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Maceta de flores de carpintero
 
 # ENTITIES
 entity.CarpentersTile.name=Tile de carpintero
+entity.CarpentersBlocks.CarpentersTile.name=Tile de carpintero
 
 # MESSAGES
 message.polarity_pos.name=POLARIDAD: Salida normal de redstone.

--- a/src/main/resources/assets/carpentersblocks/lang/fr_CA.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/fr_CA.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Pot de fleurs de charpentier
 
 # ENTITIES
 entity.CarpentersTile.name=Tuile de charpentier
+entity.CarpentersBlocks.CarpentersTile.name=Tuile de charpentier
 
 # MESSAGES
 message.polarity_pos.name=POLARITÉ : sortie normale de redstone.

--- a/src/main/resources/assets/carpentersblocks/lang/fr_CA.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/fr_CA.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Pot de fleurs de charpentier
 gui.tile.blockCarpentersSafe.title=Coffre-fort de charpentier
 
 # ENTITIES
-entity.CarpentersTile.name=Tuile de charpentier
 entity.CarpentersBlocks.CarpentersTile.name=Tuile de charpentier
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/fr_FR.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/fr_FR.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Pot de fleur du charpentier
 gui.tile.blockCarpentersSafe.title=Coffre-fort du charpentier
 
 # ENTITIES
-entity.CarpentersTile.name=Tuile du charpentier
 entity.CarpentersBlocks.CarpentersTile.name=Tuile du charpentier
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/fr_FR.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/fr_FR.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Pot de fleur du charpentier
 
 # ENTITIES
 entity.CarpentersTile.name=Tuile du charpentier
+entity.CarpentersBlocks.CarpentersTile.name=Tuile du charpentier
 
 # MESSAGES
 message.polarity_pos.name=POLARITE: Sortie redstone normale.

--- a/src/main/resources/assets/carpentersblocks/lang/it_IT.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/it_IT.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Vaso da fiori del carpentiere
 gui.tile.blockCarpentersSafe.title=Cassaforte del carpentiere
 
 # ENTITIES
-entity.CarpentersTile.name=Facciata del carpentiere
 entity.CarpentersBlocks.CarpentersTile.name=Facciata del carpentiere
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/it_IT.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/it_IT.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Vaso da fiori del carpentiere
 
 # ENTITIES
 entity.CarpentersTile.name=Facciata del carpentiere
+entity.CarpentersBlocks.CarpentersTile.name=Facciata del carpentiere
 
 # MESSAGES
 message.polarity_pos.name=POLARITA': Segnale di pietrarossa normale.

--- a/src/main/resources/assets/carpentersblocks/lang/ko_KR.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/ko_KR.lang
@@ -35,6 +35,7 @@ tile.blockCarpentersFlowerPot.name=목수의 화분
 
 # ENTITIES
 entity.CarpentersTile.name=목수의 타일
+entity.CarpentersBlocks.CarpentersTile.name=목수의 타일
 
 # MESSAGES
 message.polarity_pos.name=레드스톤: 보통

--- a/src/main/resources/assets/carpentersblocks/lang/ko_KR.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/ko_KR.lang
@@ -37,7 +37,6 @@ tile.blockCarpentersFlowerPot.name=목수의 화분
 gui.tile.blockCarpentersSafe.title=목수의 금고
 
 # ENTITIES
-entity.CarpentersTile.name=목수의 타일
 entity.CarpentersBlocks.CarpentersTile.name=목수의 타일
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/nl_NL.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/nl_NL.lang
@@ -35,6 +35,7 @@ tile.blockCarpentersFlowerPot.name=Timmermans Bloempot
 
 # ENTITIES
 entity.CarpentersTile.name=Timmermans Tegel
+entity.CarpentersBlocks.CarpentersTile.name=Timmermans Tegel
 
 # MESSAGES
 message.polarity_pos.name=POLARITEIT: Normaal redstone signaal.

--- a/src/main/resources/assets/carpentersblocks/lang/nl_NL.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/nl_NL.lang
@@ -37,7 +37,6 @@ tile.blockCarpentersFlowerPot.name=Timmermans Bloempot
 gui.tile.blockCarpentersSafe.title=Timmermans Kluis
 
 # ENTITIES
-entity.CarpentersTile.name=Timmermans Tegel
 entity.CarpentersBlocks.CarpentersTile.name=Timmermans Tegel
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/pt_BR.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/pt_BR.lang
@@ -35,6 +35,7 @@ tile.blockCarpentersFlowerPot.name=Vaso do Carpinteiro
 
 # ENTITIES
 entity.CarpentersTile.name=Ladrilho do Carpinteiro
+entity.CarpentersBlocks.CarpentersTile.name=Ladrilho do Carpinteiro
 
 # MESSAGES
 message.polarity_pos.name=POLARIDADE: Saída de redstone normal.

--- a/src/main/resources/assets/carpentersblocks/lang/pt_BR.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/pt_BR.lang
@@ -37,7 +37,6 @@ tile.blockCarpentersFlowerPot.name=Vaso do Carpinteiro
 gui.tile.blockCarpentersSafe.title=Cofre do Carpinteiro
 
 # ENTITIES
-entity.CarpentersTile.name=Ladrilho do Carpinteiro
 entity.CarpentersBlocks.CarpentersTile.name=Ladrilho do Carpinteiro
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/ru_RU.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/ru_RU.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=Цветочный горшок плотни�
 gui.tile.blockCarpentersSafe.title=Сейф плотника
 
 # ENTITIES
-entity.CarpentersTile.name=Плитка плотника
 entity.CarpentersBlocks.CarpentersTile.name=Плитка плотника
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/ru_RU.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/ru_RU.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=Цветочный горшок плотни�
 
 # ENTITIES
 entity.CarpentersTile.name=Плитка плотника
+entity.CarpentersBlocks.CarpentersTile.name=Плитка плотника
 
 # MESSAGES
 message.polarity_pos.name=ПОЛЯРНОСТЬ: Нормальный выходной сингнал красного камня.

--- a/src/main/resources/assets/carpentersblocks/lang/sv_SE.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/sv_SE.lang
@@ -37,7 +37,6 @@ tile.blockCarpentersFlowerPot.name=Snickarens Blomkruka
 gui.tile.blockCarpentersSafe.title=Snickarens Kassaskåp
 
 # ENTITIES
-entity.CarpentersTile.name=Snickarens Kakelplatta
 entity.CarpentersBlocks.CarpentersTile.name=Snickarens Kakelplatta
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/sv_SE.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/sv_SE.lang
@@ -35,6 +35,7 @@ tile.blockCarpentersFlowerPot.name=Snickarens Blomkruka
 
 # ENTITIES
 entity.CarpentersTile.name=Snickarens Kakelplatta
+entity.CarpentersBlocks.CarpentersTile.name=Snickarens Kakelplatta
 
 # MESSAGES
 message.polarity_pos.name=POLARITET: Normal rödstens-utsignal.

--- a/src/main/resources/assets/carpentersblocks/lang/zh_CN.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/zh_CN.lang
@@ -38,7 +38,6 @@ tile.blockCarpentersFlowerPot.name=木匠花盆
 gui.tile.blockCarpentersSafe.title=木匠保险箱
 
 # ENTITIES
-entity.CarpentersTile.name=木匠瓷砖
 entity.CarpentersBlocks.CarpentersTile.name=木匠瓷砖
 
 # MESSAGES

--- a/src/main/resources/assets/carpentersblocks/lang/zh_CN.lang
+++ b/src/main/resources/assets/carpentersblocks/lang/zh_CN.lang
@@ -36,6 +36,7 @@ tile.blockCarpentersFlowerPot.name=木匠花盆
 
 # ENTITIES
 entity.CarpentersTile.name=木匠瓷砖
+entity.CarpentersBlocks.CarpentersTile.name=木匠瓷砖
 
 # MESSAGES
 message.polarity_pos.name=输出相: 标准红石信号输出.


### PR DESCRIPTION
Fixes [#22940](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22940).

Note that the old key is left intact - while I suspect that the old key might have been incorrectly added originally, the Git history does not clarify why that line was added - and it's certainly possible that key is used somewhere else as well.